### PR TITLE
Fixes a little typo (possible breaking change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This is the contents of the published translation file:
 
 ```php
 return [
-    'character_seperator' => ' / ',
+    'character_separator' => ' / ',
     'character_label' => 'characters',
 ];
 ```

--- a/resources/lang/en/character-counter.php
+++ b/resources/lang/en/character-counter.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'character_seperator' => ' / ',
+    'character_separator' => ' / ',
     'character_label' => 'characters',
 ];

--- a/resources/lang/es/character-counter.php
+++ b/resources/lang/es/character-counter.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'character_seperator' => ' / ',
+    'character_separator' => ' / ',
     'character_label' => 'caracteres',
 ];

--- a/resources/lang/nl/character-counter.php
+++ b/resources/lang/nl/character-counter.php
@@ -1,6 +1,6 @@
 <?php
 
 return [
-    'character_seperator' => ' / ',
+    'character_separator' => ' / ',
     'character_label' => 'karakters',
 ];

--- a/resources/views/partials/character-count-container.blade.php
+++ b/resources/views/partials/character-count-container.blade.php
@@ -1,3 +1,3 @@
 <div class="fi-input-charcounter relative bottom-0.5 text-end text-xs px-2" @if($getCharacterLimit()) :class="{ 'text-danger-500': characterCount > {{ $getCharacterLimit() }} }" @endif>
-    <span x-text="characterCount"></span>@if($getCharacterLimit()){{ __('filament-character-counter::character-counter.character_seperator') }}{{ $getCharacterLimit() }}@endif {{ __('filament-character-counter::character-counter.character_label') }}
+    <span x-text="characterCount"></span>@if($getCharacterLimit()){{ __('filament-character-counter::character-counter.character_separator') }}{{ $getCharacterLimit() }}@endif {{ __('filament-character-counter::character-counter.character_label') }}
 </div>


### PR DESCRIPTION
It should be separator as opposed to seperator.

@schmeits i am not sure if that would be considered a breaking change, since already published translations would have a non-matching key. 

Leaving it for good measures anyway.🤓