### PR TITLE
Fix textarea with showInsideControl

### DIFF
--- a/resources/views/textarea.blade.php
+++ b/resources/views/textarea.blade.php
@@ -80,6 +80,9 @@
                 }}
             ></textarea>
         </div>
+        @if ($showInsideControl)
+            @include('filament-character-counter::partials.character-count-container')
+        @endif
     </x-filament::input.wrapper>
     @if (!$showInsideControl)
         @include('filament-character-counter::partials.character-count-container')


### PR DESCRIPTION
Hi!

I don't know why, but a few lines seems to be missing from the textarea view.

It causes the counter to not appear when using `showInsideControl()` method.

This PR should fix that issue.