### PR TITLE
Make CSS asset optional

### DIFF
--- a/config/character-counter.php
+++ b/config/character-counter.php
@@ -1,4 +1,18 @@
 <?php
 
 return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Load CSS Assets
+    |--------------------------------------------------------------------------
+    |
+    | This option controls whether the package's CSS assets should be
+    | automatically loaded. Set this to false if you want to handle
+    | the styling yourself or include the CSS manually.
+    |
+    */
+
+    'load_css' => true,
+
 ];

--- a/src/FilamentCharacterCounterServiceProvider.php
+++ b/src/FilamentCharacterCounterServiceProvider.php
@@ -49,10 +49,12 @@ class FilamentCharacterCounterServiceProvider extends PackageServiceProvider
     public function packageBooted(): void
     {
         // Asset Registration
-        FilamentAsset::register(
-            $this->getAssets(),
-            $this->getAssetPackageName()
-        );
+        if (config('character-counter.load_css', true)) {
+            FilamentAsset::register(
+                $this->getAssets(),
+                $this->getAssetPackageName()
+            );
+        }
     }
 
     protected function getAssetPackageName(): string


### PR DESCRIPTION
- Added configuration option to allow users to disable automatic CSS loading
- Introduced load_css config setting (defaults to `true` for backward compatibility) that controls whether the package's CSS assets are automatically registered with Filament

This change provides more flexibility for users who want to handle character counter styling manually or include the CSS through their own build process.
