### PR TITLE
feat: add showCharacterCounter() for conditional counter display

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to `filament-character-counter` will be documented in this file.
 
+## Unreleased
+
+### Added
+- `showCharacterCounter(bool|Closure $condition = true)` method to conditionnally display the character counter on individual fields
+
 ## v5.0.1 - 2026-03-26
 
 ## Fixed

--- a/README.md
+++ b/README.md
@@ -73,6 +73,20 @@ TextInput::make('title')
     ->characterLimit(50),
 ```
 
+You can also conditionally show or hide the coutner on a per-field basis:
+
+```php
+// Hide the counter on this field
+TextInput::make('slug')
+    ->showCharacterCounter(false)
+    ->characterLimit(100),
+
+// Conditionally display via Closure
+Textarea::make('bio')
+    ->showCharacterCounter(fn (Get $get) => $get('is_pulic'))
+    ->characterLimit(255),
+```
+
 
 ## Testing
 

--- a/resources/views/rich-editor.blade.php
+++ b/resources/views/rich-editor.blade.php
@@ -234,7 +234,7 @@
             </div>
         </x-filament::input.wrapper>
 
-        @if (!$isShownInsideControl())
+        @if (!$isShownInsideControl() && $getShowCharacterCounter())
             @include('filament-character-counter::partials.character-count-container')
         @endif
     </div>

--- a/resources/views/text-input.blade.php
+++ b/resources/views/text-input.blade.php
@@ -107,11 +107,11 @@
             }}
             @keyup="characterCount = $event.target.value.length"
         />
-        @if ($isShownInsideControl())
+        @if ($isShownInsideControl() && $getShowCharacterCounter())
             @include('filament-character-counter::partials.character-count-container')
         @endif
     </x-filament::input.wrapper>
-    @if (!$isShownInsideControl())
+    @if (!$isShownInsideControl() && $getShowCharacterCounter())
         @include('filament-character-counter::partials.character-count-container')
     @endif
 

--- a/resources/views/textarea.blade.php
+++ b/resources/views/textarea.blade.php
@@ -83,11 +83,11 @@
                 }}
             ></textarea>
         </div>
-        @if ($isShownInsideControl())
+        @if ($isShownInsideControl() && $getShowCharacterCounter())
             @include('filament-character-counter::partials.character-count-container')
         @endif
     </x-filament::input.wrapper>
-    @if (!$isShownInsideControl())
+    @if (!$isShownInsideControl() && $getShowCharacterCounter())
         @include('filament-character-counter::partials.character-count-container')
     @endif
 

--- a/src/Forms/Concerns/HasCharacterLimit.php
+++ b/src/Forms/Concerns/HasCharacterLimit.php
@@ -8,6 +8,8 @@ trait HasCharacterLimit
 {
     protected int | Closure | null $characterLimit = 0;
 
+    protected bool | Closure $showCharacterCounter = true;
+
     public function characterLimit(int | Closure | null $value = null): self
     {
         $this->characterLimit = $value;
@@ -24,5 +26,17 @@ trait HasCharacterLimit
         }
 
         return $character_limit;
+    }
+
+    public function showCharacterCounter(bool | Closure $condition = true): static
+    {
+        $this->showCharacterCounter = $condition;
+
+        return $this;
+    }
+
+    public function getShowCharacterCounter(): bool
+    {
+        return $this->evaluate($this->showCharacterCounter);
     }
 }

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -110,3 +110,55 @@ it('maxLength after characterLimit does not override the counter', function () {
         // Hard limit is maxLength
         ->and($field->getMaxLength())->toBe(200);
 });
+
+// --- showCharacterCounter ---
+
+it('shows the character counter by default on text input', function () {
+    $field = TextInput::make('test')->characterLimit(100);
+
+    expect($field->getShowCharacterCounter())->toBeTrue();
+});
+
+it('hides the character counter when set to false on text input', function () {
+    $field = TextInput::make('test')
+        ->characterLimit(100)
+        ->showCharacterCounter(false);
+
+    expect($field->getShowCharacterCounter())->toBeFalse();
+});
+
+it('shows the character counter by default on textarea', function () {
+    $field = Textarea::make('test')->characterLimit(100);
+
+    expect($field->getShowCharacterCounter())->toBeTrue();
+});
+
+it('hides the character counter when set to false on textarea', function () {
+    $field = Textarea::make('test')
+        ->characterLimit(100)
+        ->showCharacterCounter(false);
+
+    expect($field->getShowCharacterCounter())->toBeFalse();
+});
+
+it('shows the character counter by default on rich editor', function () {
+    $field = RichEditor::make('test')->characterLimit(100);
+
+    expect($field->getShowCharacterCounter())->toBeTrue();
+});
+
+it('hides the character counter when set to false on rich editor', function () {
+    $field = RichEditor::make('test')
+        ->characterLimit(100)
+        ->showCharacterCounter(false);
+
+    expect($field->getShowCharacterCounter())->toBeFalse();
+});
+
+it('accepts a closure for showCharacterCounter', function () {
+    $field = TextInput::make('test')
+        ->characterLimit(100)
+        ->showCharacterCounter(fn () => false);
+
+    expect($field->getShowCharacterCounter())->toBeFalse();
+});


### PR DESCRIPTION
Adds a `showCharacterCounter(bool|Closure $condition = true)` methoid to HasCharacterCounter, allowing users to hide the character counter on specific fileds without switching back to Filament's native input class.

- Add showCharacterCounter() and getShowCharacterCounter() to HasCharacterCounter
- Gate counter partials in text-input, textarea and rich-editor views
- Add tests for enabled/disabled states and Closure support
- Update README with usage example